### PR TITLE
Fix $PROJECT_DIR problem for paths with white spaces

### DIFF
--- a/CodePilot.xcodeproj/project.pbxproj
+++ b/CodePilot.xcodeproj/project.pbxproj
@@ -619,7 +619,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "bash $PROJECT_DIR/Installer/build_installer_pkg.command\n";
+			shellScript = "bash \"$PROJECT_DIR/Installer/build_installer_pkg.command\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
First thing I've just spotted while trying to build your plugin.
