### PR TITLE
Plugin UUID for Xcode 6 GM

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -58,6 +58,7 @@
 		<string>63FC1C47-140D-42B0-BB4D-A10B2D225574</string>
 		<string>37B30044-3B14-46BA-ABAA-F01000C27B63</string>
 		<string>A2E4D43F-41F4-4FB9-BB94-7177011C9AED</string>
+		<string>C4A681B0-4A26-480E-93EC-1218098B9AA0</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Added the UUID for Xcode 6 GM.

Installs and works fine.