### PR TITLE
Fixes #18. Adds support for Xcode 6.0

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -36,6 +36,14 @@
 	<string>0400</string>
 	<key>DTXcodeBuild</key>
 	<string></string>
+	<key>DVTPlugInCompatibilityUUIDs</key>
+	<array>
+		<string>640F884E-CE55-4B40-87C0-8869546CAB7A</string>
+		<string>63FC1C47-140D-42B0-BB4D-A10B2D225574</string>
+		<string>37B30044-3B14-46BA-ABAA-F01000C27B63</string>
+		<string>A2E4D43F-41F4-4FB9-BB94-7177011C9AED</string>
+		<string>C4A681B0-4A26-480E-93EC-1218098B9AA0</string>
+	</array>
 	<key>NSPrincipalClass</key>
 	<string>CPCodePilotPlugin</string>
 	<key>SUEnableAutomaticChecks</key>
@@ -52,12 +60,5 @@
 	<string>YES</string>
 	<key>XCPluginHasUI</key>
 	<string>NO</string>
-	<key>DVTPlugInCompatibilityUUIDs</key>
-	<array>
-		<string>640F884E-CE55-4B40-87C0-8869546CAB7A</string>
-		<string>63FC1C47-140D-42B0-BB4D-A10B2D225574</string>
-		<string>37B30044-3B14-46BA-ABAA-F01000C27B63</string>
-		<string>A2E4D43F-41F4-4FB9-BB94-7177011C9AED</string>
-	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Added the `Compatibility UUID` for `Xcode 6.0`

Signed-off-by: Esteban Torres <me@estebantorr.es>