### PR TITLE
Adding Xcode 6.3 support

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -38,6 +38,9 @@
 	<string></string>
 	<key>DVTPlugInCompatibilityUUIDs</key>
 	<array>
+		<string>FEC992CC-CA4A-4CFD-8881-77300FCB848A</string>
+		<string>AD68E85B-441B-4301-B564-A45E4919A6AD</string>
+		<string>9F75337B-21B4-4ADC-B558-F9CADF7073A7</string>
 		<string>992275C1-432A-4CF7-B659-D84ED6D42D3F</string>
 		<string>A16FF353-8441-459E-A50C-B071F53F51B7</string>
 		<string>640F884E-CE55-4B40-87C0-8869546CAB7A</string>


### PR DESCRIPTION
Adding `DVTPluginCompatibilityUUIDs` for Xcode 6.3 support